### PR TITLE
Pull Request: Refactor Field Creation Logic in FieldServiceImpl

### DIFF
--- a/src/main/java/com/citronix/citronix/controller/FieldController.java
+++ b/src/main/java/com/citronix/citronix/controller/FieldController.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/fields")
-@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+@RequiredArgsConstructor
 @Validated
 public class FieldController {
 
@@ -38,7 +38,7 @@ public class FieldController {
     }
 
     @PostMapping
-    public ResponseEntity<FieldResponseDTO> createField(@RequestBody @Valid FieldRequestDTO fieldRequestDTO) {
+    public ResponseEntity<FieldResponseDTO> createField(@Valid @RequestBody FieldRequestDTO fieldRequestDTO) {
         FieldResponseDTO createdField = fieldService.create(fieldRequestDTO);
         return new ResponseEntity<>(createdField, HttpStatus.CREATED);
     }
@@ -46,9 +46,9 @@ public class FieldController {
     @PutMapping("/{id}")
     public ResponseEntity<FieldResponseDTO> updateField(
             @PathVariable Long id,
-            @RequestBody FieldRequestDTO fieldRequestDTO) {
+            @Valid @RequestBody FieldRequestDTO fieldRequestDTO) {
         FieldResponseDTO updatedField = fieldService.update(id, fieldRequestDTO);
-        return ResponseEntity.ok(updatedField);
+        return ResponseEntity.status(HttpStatus.OK).body(updatedField);
     }
 
     @DeleteMapping("/{id}")


### PR DESCRIPTION
**### Summary of changes**

This PR refactors the logic for creating fields in the FieldServiceImpl service. The main changes include:

**Improved field validation:**

Verification of minimum field area (1000 m²).
Validation if field area exceeds 50% of total farm area.
Validation to ensure total field area does not exceed farm area.
Separation of concerns :

Validation logic has been extracted into dedicated methods, such as validateTotalFarmSurface, to make the code more readable and maintainable.
Improved error handling:

More explicit exception messages have been added for each type of validation (e.g. “Field surface must not exceed 50% of total farm surface”).
Use of custom exceptions (EntityConstraintViolationException) to handle constraint errors.
Optimized field update logic:

When a field is updated, the total surface area of the farm's fields is recalculated, taking into account the excluded field.

